### PR TITLE
Add copy-to-clipboard support to code blocks

### DIFF
--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -124,12 +124,14 @@ public enum RenderBlockContent: Equatable {
         public var code: [String]
         /// Additional metadata for this code block.
         public var metadata: RenderContentMetadata?
+        public var copyToClipboard: Bool = false
 
         /// Make a new `CodeListing` with the given data.
-        public init(syntax: String?, code: [String], metadata: RenderContentMetadata?) {
+        public init(syntax: String?, code: [String], metadata: RenderContentMetadata?, copyToClipboard: Bool) {
             self.syntax = syntax
             self.code = code
             self.metadata = metadata
+            self.copyToClipboard = copyToClipboard
         }
     }
 
@@ -697,7 +699,7 @@ extension RenderBlockContent.Table: Codable {
 extension RenderBlockContent: Codable {
     private enum CodingKeys: CodingKey {
         case type
-        case inlineContent, content, caption, style, name, syntax, code, level, text, items, media, runtimePreview, anchor, summary, example, metadata, start
+        case inlineContent, content, caption, style, name, syntax, code, level, text, items, media, runtimePreview, anchor, summary, example, metadata, start, copyToClipboard
         case request, response
         case header, rows
         case numberOfColumns, columns
@@ -722,7 +724,8 @@ extension RenderBlockContent: Codable {
             self = try .codeListing(.init(
                 syntax: container.decodeIfPresent(String.self, forKey: .syntax),
                 code: container.decode([String].self, forKey: .code),
-                metadata: container.decodeIfPresent(RenderContentMetadata.self, forKey: .metadata)
+                metadata: container.decodeIfPresent(RenderContentMetadata.self, forKey: .metadata),
+                copyToClipboard: container.decode(Bool.self, forKey: .copyToClipboard)
             ))
         case .heading:
             self = try .heading(.init(level: container.decode(Int.self, forKey: .level), text: container.decode(String.self, forKey: .text), anchor: container.decodeIfPresent(String.self, forKey: .anchor)))

--- a/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
+++ b/Sources/SwiftDocC/Model/Rendering/Content/RenderBlockContent.swift
@@ -725,7 +725,7 @@ extension RenderBlockContent: Codable {
                 syntax: container.decodeIfPresent(String.self, forKey: .syntax),
                 code: container.decode([String].self, forKey: .code),
                 metadata: container.decodeIfPresent(RenderContentMetadata.self, forKey: .metadata),
-                copyToClipboard: container.decode(Bool.self, forKey: .copyToClipboard)
+                copyToClipboard: container.decodeIfPresent(Bool.self, forKey: .copyToClipboard) ?? false
             ))
         case .heading:
             self = try .heading(.init(level: container.decode(Int.self, forKey: .level), text: container.decode(String.self, forKey: .text), anchor: container.decodeIfPresent(String.self, forKey: .anchor)))
@@ -829,6 +829,7 @@ extension RenderBlockContent: Codable {
             try container.encode(l.syntax, forKey: .syntax)
             try container.encode(l.code, forKey: .code)
             try container.encodeIfPresent(l.metadata, forKey: .metadata)
+            try container.encode(l.copyToClipboard, forKey: .copyToClipboard)
         case .heading(let h):
             try container.encode(h.level, forKey: .level)
             try container.encode(h.text, forKey: .text)

--- a/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
+++ b/Sources/SwiftDocC/Model/Rendering/RenderContentCompiler.swift
@@ -47,7 +47,7 @@ struct RenderContentCompiler: MarkupVisitor {
     
     mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> [any RenderContent] {
         // Default to the bundle's code listing syntax if one is not explicitly declared in the code block.
-        return [RenderBlockContent.codeListing(.init(syntax: codeBlock.language ?? bundle.info.defaultCodeListingLanguage, code: codeBlock.code.splitByNewlines, metadata: nil))]
+        return [RenderBlockContent.codeListing(.init(syntax: codeBlock.language ?? bundle.info.defaultCodeListingLanguage, code: codeBlock.code.splitByNewlines, metadata: nil, copyToClipboard: false))]
     }
     
     mutating func visitHeading(_ heading: Heading) -> [any RenderContent] {

--- a/Sources/SwiftDocC/Model/Section/Sections/DefaultImplementations.swift
+++ b/Sources/SwiftDocC/Model/Section/Sections/DefaultImplementations.swift
@@ -65,7 +65,7 @@ public struct DefaultImplementationsSection {
                 
                 return ImplementationsGroup(
                     heading: "\(groupName)Implementations",
-                    references: grouped[name]!.map { $0.reference }
+                    references: grouped[name]!.map { $0.reference }.sorted(by: \.description)
                 )
             }
     }

--- a/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
+++ b/Sources/SwiftDocC/Semantics/Snippets/Snippet.swift
@@ -68,11 +68,12 @@ extension Snippet: RenderableDirectiveConvertible {
                 let lines = snippetMixin.lines[lineRange]
                 let minimumIndentation = lines.map { $0.prefix { $0.isWhitespace }.count }.min() ?? 0
                 let trimmedLines = lines.map { String($0.dropFirst(minimumIndentation)) }
-                return [RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: trimmedLines, metadata: nil))]
+                let copy = true
+                return [RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: trimmedLines, metadata: nil, copyToClipboard: copy))]
             } else {
                 // Render the whole snippet with its explanation content.
                 let docCommentContent = snippetEntity.markup.children.flatMap { contentCompiler.visit($0) }
-                let code = RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: snippetMixin.lines, metadata: nil))
+                let code = RenderBlockContent.codeListing(.init(syntax: snippetMixin.language, code: snippetMixin.lines, metadata: nil, copyToClipboard: false))
                 return docCommentContent + [code]
             }
     }

--- a/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
+++ b/Sources/SwiftDocC/SwiftDocC.docc/Resources/RenderNode.spec.json
@@ -805,6 +805,9 @@
                     },
                     "metadata": {
                         "$ref": "#/components/schemas/RenderContentMetadata"
+                    },
+                    "copyToClipboard": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
+++ b/Sources/docc/DocCDocumentation.docc/formatting-your-documentation-content.md
@@ -143,6 +143,24 @@ add a new line and terminate the code listing by adding another three backticks:
 instead of tabs so that DocC preserves the indentation when compiling your 
 documentation.
 
+#### Formatting Code Listings
+
+You can add a copy-to-clipboard button to a code listing by including the copy
+option after the name of the programming language for the code listing:
+
+```swift, copy
+struct Sightseeing: Activity {
+    func perform(with sloth: inout Sloth) -> Speed {
+        sloth.energyLevel -= 10
+        return .slow
+    }
+}
+```
+
+This renders a copy button in the top-right cotner of the code listing in
+generated documentation. When clicked, it copies the contents of the code
+block to the clipboard.
+
 DocC uses the programming language you specify to apply the correct syntax 
 color formatting. For the example above, DocC generates the following:
 

--- a/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderContentMetadataTests.swift
@@ -54,7 +54,7 @@ class RenderContentMetadataTests: XCTestCase {
             RenderInlineContent.text("Content"),
         ])
         
-        let code = RenderBlockContent.codeListing(.init(syntax: nil, code: [], metadata: metadata))
+        let code = RenderBlockContent.codeListing(.init(syntax: nil, code: [], metadata: metadata, copyToClipboard: false))
         let data = try JSONEncoder().encode(code)
         let roundtrip = try JSONDecoder().decode(RenderBlockContent.self, from: data)
         

--- a/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
+++ b/Tests/SwiftDocCTests/Model/RenderNodeSerializationTests.swift
@@ -44,7 +44,7 @@ class RenderNodeSerializationTests: XCTestCase {
                     .strong(inlineContent: [.text("Project > Run")]),
                     .text(" menu item, or the following code:"),
                 ])),
-                .codeListing(.init(syntax: "swift", code: ["xcrun xcodebuild -h", "xcrun xcodebuild build -configuration Debug"], metadata: nil)),
+                .codeListing(.init(syntax: "swift", code: ["xcrun xcodebuild -h", "xcrun xcodebuild build -configuration Debug"], metadata: nil, copyToClipboard: false)),
             ]))
         ]
         
@@ -71,16 +71,16 @@ class RenderNodeSerializationTests: XCTestCase {
         let assessment1 = TutorialAssessmentsRenderSection.Assessment(title: [.paragraph(.init(inlineContent: [.text("Lorem ipsum dolor sit amet?")]))],
                                                                      content: nil,
                                                                      choices: [
-            .init(content: [.codeListing(.init(syntax: "swift", code: ["override func viewDidLoad() {", "super.viewDidLoad()", "}"], metadata: nil))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "That's right!"),
-            .init(content: [.codeListing(.init(syntax: "swift", code: ["sceneView.delegate = self"], metadata: nil))], isCorrect: false, justification: [.paragraph(.init(inlineContent: [.text("It's incorrect because...")]))], reaction: "Not quite."),
+            .init(content: [.codeListing(.init(syntax: "swift", code: ["override func viewDidLoad() {", "super.viewDidLoad()", "}"], metadata: nil, copyToClipboard: false))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "That's right!"),
+            .init(content: [.codeListing(.init(syntax: "swift", code: ["sceneView.delegate = self"], metadata: nil, copyToClipboard: false))], isCorrect: false, justification: [.paragraph(.init(inlineContent: [.text("It's incorrect because...")]))], reaction: "Not quite."),
             .init(content: [.paragraph(.init(inlineContent: [.text("None of the above.")]))], isCorrect: false, justification: [.paragraph(.init(inlineContent: [.text("It's incorrect because...")]))], reaction: nil),
         ])
         
         let assessment2 = TutorialAssessmentsRenderSection.Assessment(title: [.paragraph(.init(inlineContent: [.text("Duis aute irure dolor in reprehenderit?")]))],
                                                                      content: [.paragraph(.init(inlineContent: [.text("What is the airspeed velocity of an unladen swallow?")]))],
                                                                      choices: [
-            .init(content: [.codeListing(.init(syntax: "swift", code: ["super.viewWillAppear()"], metadata: nil))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "Correct."),
-            .init(content: [.codeListing(.init(syntax: "swift", code: ["sceneView.delegate = self"], metadata: nil))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "Yep."),
+            .init(content: [.codeListing(.init(syntax: "swift", code: ["super.viewWillAppear()"], metadata: nil, copyToClipboard: false))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "Correct."),
+            .init(content: [.codeListing(.init(syntax: "swift", code: ["sceneView.delegate = self"], metadata: nil, copyToClipboard: false))], isCorrect: true, justification: [.paragraph(.init(inlineContent: [.text("It's correct because...")]))], reaction: "Yep."),
             .init(content: [.paragraph(.init(inlineContent: [.text("None of the above.")]))], isCorrect: false, justification: [.paragraph(.init(inlineContent: [.text("It's incorrect because...")]))], reaction: "Close!"),
         ])
         

--- a/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
@@ -224,8 +224,8 @@ class RenderContentCompilerTests: XCTestCase {
         }
     }
 
-    func testCopyToClipboard() throws {
-        let (bundle, context) = try testBundleAndContext()
+    func testCopyToClipboard() async throws {
+        let (bundle, context) = try await testBundleAndContext()
         var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
 
         let source = #"""

--- a/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
+++ b/Tests/SwiftDocCTests/Rendering/RenderContentCompilerTests.swift
@@ -223,4 +223,26 @@ class RenderContentCompilerTests: XCTestCase {
             XCTAssertEqual(documentThematicBreak, thematicBreak)
         }
     }
+
+    func testCopyToClipboard() throws {
+        let (bundle, context) = try testBundleAndContext()
+        var compiler = RenderContentCompiler(context: context, bundle: bundle, identifier: ResolvedTopicReference(bundleID: bundle.id, path: "/path", fragment: nil, sourceLanguage: .swift))
+
+        let source = #"""
+        ```swift, copy
+        let x = 1
+        ```
+        """#
+        let document = Document(parsing: source)
+
+        let result = document.children.flatMap { compiler.visit($0) }
+
+        let renderCodeBlock = try XCTUnwrap(result[0] as? RenderBlockContent)
+        guard case let .codeListing(codeListing) = renderCodeBlock else {
+            XCTFail("Expected RenderBlockContent.codeListing")
+            return
+        }
+
+        XCTAssertEqual(codeListing.copyToClipboard, true)
+    }
 }

--- a/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
+++ b/Tests/SwiftDocCTests/Utility/ListItemExtractorTests.swift
@@ -514,7 +514,7 @@ class ListItemExtractorTests: XCTestCase {
             // ```
             // Inner code block
             // ```
-            .codeListing(.init(syntax: nil, code: ["Inner code block"], metadata: nil)),
+            .codeListing(.init(syntax: nil, code: ["Inner code block"], metadata: nil, copyToClipboard: false)),
         
             // > Warning: Inner aside, with ``ThirdNotFoundSymbol`` link
             .aside(.init(style: .init(asideKind: .warning), content: [


### PR DESCRIPTION
## Summary

This PR adds support for a `copy` option in code blocks. When this option is enabled, a copy-to-clipboard button is rendered in the top-right corner of the code block, allowing users to easily copy its contents.

### User Experience

If a code block includes the `copy` keyword in the language line, a copy button will appear when the user hovers over the block. Clicking the button copies the full contents of the code block to the clipboard and displays a checkmark to confirm success.

### Implementation Overview

- In `swift-docc`, this change parses the `copy` option from the language line in triple-backtick code blocks.
- A `copyToClipboard` property was added to `RenderBlockContent.codeListing` passed to the renderer.
- This flag is forwarded to `swift-docc-render`. The accompanying branch/PR is here: (forthcoming)

## Dependencies

This PR depends on associated changes in `swift-docc-render` to actually render and handle the copy button.

## Testing

### Setup
1. Use the codeblock-copy branches for `swift-docc` and `swift-docc-render` with the copy-to-clipboard changes.
2. Rebuild documentation using `swift-docc` and serve it using a local build of `swift-docc-render`.

### How to Test
1. In any code listing using ` ``` ` or by adding a code listing, add the copy option like this:

``````
﻿```swift, copy
﻿print(“Hello, world!”)
﻿```
``````
﻿
﻿or like this:
﻿
``````
﻿```copy
﻿print(“Hello, world!”)
﻿```
``````
﻿
2. Hover over the code block. A copy icon should appear in the top-right corner.
3. Click the copy icon. The code should be copied to your clipboard and the icon should update to a checkmark briefly. Paste to verify the copy functionality works.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests – `testCopyToClipboard()` in `RenderContentCompilerTests.swift`
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary – I added `copyToClipboard` as a property of `CodeListing` in `RenderNode.spec.json`. I also added a subsection to Formatting Your Documentation Content. Please let me know if there’s any other documentation I should update.
